### PR TITLE
Changing IParticleContainers to ParticleContainers so we can carry mo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Now we can checkout our dependencies using the following :
 
 ```
 git clone https://github.com/lawrenceleejr/Ext_RestFrames.git
-rc checkout_pkg atlasoff/PhysicsAnalysis/TopPhys/QuickAna/tags QuickAna
-rc checkout_pkg svn+ssh://svn.cern.ch/reps/atlasinst/Institutes/LBNL/AnalysisToolsRunII/CommonTools/tags CommonTools
+rc checkout_pkg atlasoff/PhysicsAnalysis/TopPhys/QuickAna/tags/QuickAna-00-00-94 QuickAna
+rc checkout_pkg svn+ssh://svn.cern.ch/reps/atlasinst/Institutes/LBNL/AnalysisToolsRunII/CommonTools/tags/CommonTools-00-00-17 CommonTools
 git clone https://github.com/UCATLAS/xAODAnaHelpers.git
 ```
 

--- a/RJigsawTools/RJigsawCalculator.h
+++ b/RJigsawTools/RJigsawCalculator.h
@@ -4,7 +4,8 @@
 //date   : December 2015
 
 #include "EventLoop/StatusCode.h"
-#include "xAODBase/IParticleContainer.h"
+// #include "xAODBase/IParticleContainer.h"
+#include "xAODParticleEvent/ParticleContainer.h"
 #include "xAODMissingET/MissingET.h"
 
 #include <unordered_map>
@@ -29,7 +30,7 @@ public :
   //to be used per event
   EL::StatusCode clearEvent(){m_clearEventCalled = CALLED;return doClearEvent();}
   EL::StatusCode calculate(std::unordered_map<std::string, double>& RJVars,
-			   xAOD::IParticleContainer& particles,
+			   xAOD::ParticleContainer& particles,
 			   xAOD::MissingET & met
 			   ){
     if(m_clearEventCalled == NOTCALLED){
@@ -47,7 +48,7 @@ private :
   virtual EL::StatusCode doInitialize(){std::cout << "you called the base calculator function! Exiting" << std::endl;return EL::StatusCode::FAILURE;};
   virtual EL::StatusCode doClearEvent(){std::cout << "you called the base calculator function! Exiting" << std::endl;return EL::StatusCode::FAILURE;};
   virtual EL::StatusCode doCalculate(std::unordered_map<std::string, double>& RJVars,
-                                     xAOD::IParticleContainer& particles,
+                                     xAOD::ParticleContainer& particles,
                                      xAOD::MissingET& met
                                      ){std::cout << "you called the base calculator function! Exiting" << std::endl;return EL::StatusCode::FAILURE;};
 

--- a/RJigsawTools/RJigsawCalculator_lvlv.h
+++ b/RJigsawTools/RJigsawCalculator_lvlv.h
@@ -61,7 +61,7 @@ private :
   virtual EL::StatusCode doInitialize();
   virtual EL::StatusCode doClearEvent();
   virtual EL::StatusCode doCalculate(std::unordered_map<std::string, double>& RJVars,
-                                     xAOD::IParticleContainer& particles,
+                                     xAOD::ParticleContainer& particles,
                                      xAOD::MissingET& met
                                      );
   // this is needed to distribute the algorithm to the workers

--- a/RJigsawTools/RJigsawCalculator_zl.h
+++ b/RJigsawTools/RJigsawCalculator_zl.h
@@ -66,7 +66,7 @@ private :
   virtual EL::StatusCode doInitialize();
   virtual EL::StatusCode doClearEvent();
   virtual EL::StatusCode doCalculate(std::unordered_map<std::string, double>& RJVars,
-                                     xAOD::IParticleContainer& particles,
+                                     xAOD::ParticleContainer& particles,
                                      xAOD::MissingET& met
                                      );
   // this is needed to distribute the algorithm to the workers

--- a/Root/RJigsawCalculator_lvlv.cxx
+++ b/Root/RJigsawCalculator_lvlv.cxx
@@ -131,7 +131,7 @@ EL::StatusCode RJigsawCalculator_lvlv::doInitialize() {
 }
 
 EL::StatusCode RJigsawCalculator_lvlv::doCalculate(std::unordered_map<std::string, double>& RJVars,
-						   xAOD::IParticleContainer& particles,
+						   xAOD::ParticleContainer& particles,
 						   xAOD::MissingET& met
 						   ){
   if( particles.size() < 2 ){return EL::StatusCode::SUCCESS;}//todo figure out if this how we should handle this case

--- a/Root/RJigsawCalculator_zl.cxx
+++ b/Root/RJigsawCalculator_zl.cxx
@@ -231,7 +231,7 @@ EL::StatusCode RJigsawCalculator_zl::doInitialize() {
 }
 
 EL::StatusCode RJigsawCalculator_zl::doCalculate(std::unordered_map<std::string, double>& RJVars,
-						   xAOD::IParticleContainer& particles,
+						   xAOD::ParticleContainer& particles,
 						   xAOD::MissingET& met
 						   ){
   if( particles.size() < 2 ){return EL::StatusCode::SUCCESS;}//todo figure out if this how we should handle this case

--- a/test/ut_rjigsawcalculator_lvlv_test.cxx
+++ b/test/ut_rjigsawcalculator_lvlv_test.cxx
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <xAODMissingET/MissingET.h>
 #include <xAODJet/JetContainer.h>
+#include <xAODParticleEvent/ParticleContainer.h>
 
 struct RJigsawCalculator_lvlv_Test : testing::Test
 {
@@ -40,7 +41,7 @@ TEST_F (RJigsawCalculator_lvlv_Test, clearEventTest)
   calc.initialize();
 
   std::unordered_map<std::string, double> mymap;
-  xAOD::JetContainer jets;
+  xAOD::ParticleContainer jets;
   xAOD::MissingET met;
 
 


### PR DESCRIPTION
…re info through to calculators

In order to be able to access more particle information at the calculator level, I've changed the base calculator class to expect a ParticleContainer class instead of an IParticleContainer. This might be an incorrect use of the xAOD Particle object, but it allows us to attach charge and PDGID info to the object which can be useful in the calculator. (IParticle is basically just a 4 vector.)

Would be great if we could also attach e.g. a barcode. But maybe we can do that via decorators.
