### PR TITLE
fixing bug on vector access in an assert

### DIFF
--- a/Root/RJigsawCalculator_tls.cxx
+++ b/Root/RJigsawCalculator_tls.cxx
@@ -316,9 +316,12 @@ EL::StatusCode RJigsawCalculator_tls::doCalculate(std::map<std::string, double>&
     else {Jets.push_back(tmpPart);}
   }
 
-  auto ptSort = [](TLorentzVector const & a , TLorentzVector const & b){return a.Pt() > b.Pt();};
-  std::sort(Leptons.begin(),Leptons.end(), ptSort);
-  assert(Leptons.at(0).Pt() > Leptons.at(1).Pt());
+  if(Leptons.size()>1){
+    auto ptSort = [](TLorentzVector const & a , TLorentzVector const & b){return a.Pt() > b.Pt();};
+    std::sort(Leptons.begin(), Leptons.end(), ptSort);
+    assert(Leptons.at(0).Pt() > Leptons.at(1).Pt());
+  }
+
 
   vector<RFKey> jetID;
   vector<RFKey> jetID_bkg;


### PR DESCRIPTION
Screwed up a thing in #61, needed to check that the the lepton vector had more than one object before caring to sort it. Fixed here. Affects #52.
