### PR TITLE
Adding lepton SFs to TLS tree

### DIFF
--- a/Root/CalibrateST.cxx
+++ b/Root/CalibrateST.cxx
@@ -206,12 +206,12 @@ EL::StatusCode CalibrateST :: execute ()
   // Lepton Scale Factors added as decorators to eventInfo object
 
   float muSF = 1.0;
-  if ( !isData ) muSF = (float) m_objTool->GetTotalMuonSF(*muons_nominal,true,true,"HLT_mu20_iloose_L1MU15_OR_HLT_mu50");
+  if ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) ) muSF = (float) m_objTool->GetTotalMuonSF(*muons_nominal,true,true,"HLT_mu20_iloose_L1MU15_OR_HLT_mu50");
   eventInfo->auxdecor<float>("muSF") = muSF ;
 
 
   float elSF = 1.0;
-  if ( !isData ) elSF = (float) m_objTool->GetTotalElectronSF(*electrons_nominal);
+  if ( eventInfo->eventType( xAOD::EventInfo::IS_SIMULATION ) ) elSF = (float) m_objTool->GetTotalElectronSF(*electrons_nominal);
   eventInfo->auxdecor<float>("elSF") = elSF ;
 
 

--- a/Root/CalibrateST.cxx
+++ b/Root/CalibrateST.cxx
@@ -202,6 +202,19 @@ EL::StatusCode CalibrateST :: execute ()
 
   // eventInfo_shallowCopy.second->setShallowIO(true);
 
+
+  // Lepton Scale Factors added as decorators to eventInfo object
+
+  float muSF = 1.0;
+  if ( !isData ) muSF = (float) m_objTool->GetTotalMuonSF(*muons_nominal,true,true,"HLT_mu20_iloose_L1MU15_OR_HLT_mu50");
+  eventInfo->auxdecor<float>("muSF") = muSF ;
+
+
+  float elSF = 1.0;
+  if ( !isData ) elSF = (float) m_objTool->GetTotalElectronSF(*electrons_nominal);
+  eventInfo->auxdecor<float>("elSF") = elSF ;
+
+
   return EL::StatusCode::SUCCESS;
 }
 

--- a/Root/RegionVarCalculator_tls.cxx
+++ b/Root/RegionVarCalculator_tls.cxx
@@ -76,9 +76,9 @@ EL::StatusCode RegionVarCalculator_tls::doAllCalculations(std::map<std::string, 
   RegionVars["mcEventWeight"] = eventInfo->auxdecor< float >("mcEventWeight");
   RegionVars["pileupWeight"] = eventInfo->auxdecor< float >("PileupWeight");
 
+  RegionVars["elSF"] = eventInfo->auxdecor< float >("elSF");
+  RegionVars["muSF"] = eventInfo->auxdecor< float >("muSF");
 
-  std::cout <<  "mceventweight" << std::endl;
-  std::cout <<  RegionVars["mcEventWeight"] << std::endl;
 
 
   //


### PR DESCRIPTION
Adding lepton SFs from SUSYTools. Output seems to work well. 

```
root [2] trees_SR_->Scan("elSF")
************************
*    Row   *      elSF *
************************
*        0 * 0.9139994 *
*        1 * 0.9394007 *
*        2 *         1 *
*        3 * 1.0002898 *
*        4 * 0.9932210 *
*        5 * 0.9176160 *
*        6 *         1 *
*        7 *         1 *
*        8 *         1 *
*        9 *         1 *
*       10 * 0.9806132 *
*       11 * 0.9808974 *
*       12 * 0.9596663 *
*       13 * 0.9900363 *
*       14 * 1.0002898 *
*       15 * 0.9977179 *
```
